### PR TITLE
Test: Bulk PR exclusion logic

### DIFF
--- a/detection-rules/test-bulk-rule-1.yml
+++ b/detection-rules/test-bulk-rule-1.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-1.yml
+++ b/detection-rules/test-bulk-rule-1.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "cb344065-4fed-5bd9-9088-08495522982e"

--- a/detection-rules/test-bulk-rule-10.yml
+++ b/detection-rules/test-bulk-rule-10.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "94d0592e-cc80-5309-9deb-274f1e9dcb2e"

--- a/detection-rules/test-bulk-rule-10.yml
+++ b/detection-rules/test-bulk-rule-10.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-11.yml
+++ b/detection-rules/test-bulk-rule-11.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "1ed06ff4-d44a-5fbf-9d65-b88ea3785df6"

--- a/detection-rules/test-bulk-rule-11.yml
+++ b/detection-rules/test-bulk-rule-11.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-2.yml
+++ b/detection-rules/test-bulk-rule-2.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "de6ede54-848a-50eb-9d21-4d374293d07c"

--- a/detection-rules/test-bulk-rule-2.yml
+++ b/detection-rules/test-bulk-rule-2.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-3.yml
+++ b/detection-rules/test-bulk-rule-3.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "f198824b-d3fc-53d9-bf9f-f5b75380a4dc"

--- a/detection-rules/test-bulk-rule-3.yml
+++ b/detection-rules/test-bulk-rule-3.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-4.yml
+++ b/detection-rules/test-bulk-rule-4.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-4.yml
+++ b/detection-rules/test-bulk-rule-4.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "6ec0a768-6091-5331-93e0-104c286a0480"

--- a/detection-rules/test-bulk-rule-5.yml
+++ b/detection-rules/test-bulk-rule-5.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-5.yml
+++ b/detection-rules/test-bulk-rule-5.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "33706d82-fbb4-55e3-b2f7-7454ac6446e3"

--- a/detection-rules/test-bulk-rule-6.yml
+++ b/detection-rules/test-bulk-rule-6.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "bb8f8ca6-9e4a-5ae1-9e77-c6293d779011"

--- a/detection-rules/test-bulk-rule-6.yml
+++ b/detection-rules/test-bulk-rule-6.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-7.yml
+++ b/detection-rules/test-bulk-rule-7.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "220c12a8-2d8b-55d7-8d08-536d4984409e"

--- a/detection-rules/test-bulk-rule-7.yml
+++ b/detection-rules/test-bulk-rule-7.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-8.yml
+++ b/detection-rules/test-bulk-rule-8.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "d444cbca-7e36-5713-8424-87105c82f385"

--- a/detection-rules/test-bulk-rule-8.yml
+++ b/detection-rules/test-bulk-rule-8.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-9.yml
+++ b/detection-rules/test-bulk-rule-9.yml
@@ -1,0 +1,9 @@
+name: "Test bulk rule $i"
+description: "Test rule for bulk PR exclusion testing - will be deleted"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "test-bulk-pr.example.com"
+tags:
+  - "Test"

--- a/detection-rules/test-bulk-rule-9.yml
+++ b/detection-rules/test-bulk-rule-9.yml
@@ -7,3 +7,4 @@ source: |
   and sender.email.domain.domain == "test-bulk-pr.example.com"
 tags:
   - "Test"
+id: "c00ea7c2-7734-565c-a958-5bf986f5dfca"


### PR DESCRIPTION
## Summary

Testing the bulk PR exclusion logic - this PR contains 11 rules which exceeds the max of 10.

Expected behavior:
- `bulk-pr` label should be applied
- Exclusion comment should be posted

**This PR should be closed after testing.**